### PR TITLE
deb: support Debian 11 (bullseye)

### DIFF
--- a/td-agent-apt-source/apt/debian-bullseye/Dockerfile
+++ b/td-agent-apt-source/apt/debian-bullseye/Dockerfile
@@ -1,0 +1,17 @@
+FROM debian:bullseye
+
+RUN \
+  echo "debconf debconf/frontend select Noninteractive" | \
+    debconf-set-selections
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
+  apt update ${quiet} && \
+  apt install -y -V ${quiet} \
+    debhelper \
+    devscripts \
+    gnupg && \
+  apt clean && \
+  rm -rf /var/lib/apt/lists/*

--- a/td-agent/apt/commonvar.sh
+++ b/td-agent/apt/commonvar.sh
@@ -14,7 +14,7 @@ case ${code_name} in
     channel=universe
     mirror=http://archive.ubuntu.com/ubuntu/
     ;;
-  buster)
+  buster|bullseye)
     distribution=debian
     channel=main
     mirror=http://deb.debian.org/debian

--- a/td-agent/apt/debian-bullseye-arm64/from
+++ b/td-agent/apt/debian-bullseye-arm64/from
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+arm64v8/debian:bullseye

--- a/td-agent/apt/debian-bullseye/Dockerfile
+++ b/td-agent/apt/debian-bullseye/Dockerfile
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+ARG FROM=debian:bullseye
+FROM ${FROM}
+
+COPY qemu-* /usr/bin/
+
+RUN \
+  echo "debconf debconf/frontend select Noninteractive" | \
+    debconf-set-selections
+
+ARG DEBUG
+
+RUN sed -i'' -e 's/main$/main contrib non-free/g' /etc/apt/sources.list
+RUN grep '^deb' /etc/apt/sources.list | sed -e 's/^deb /deb-src /g' >> /etc/apt/sources.list
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
+  apt update ${quiet} && \
+  apt install -y -V ${quiet} \
+    build-essential \
+    debhelper \
+    devscripts \
+    ruby-dev \
+    ruby-bundler \
+    libedit2 \
+    libncurses5-dev \
+    libyaml-dev \
+    git \
+    pkg-config \
+    libssl-dev \
+    libpq-dev \
+    tar \
+    lsb-release \
+    zlib1g-dev && \
+  apt build-dep -y ruby && \
+  apt clean && \
+  # raise IPv4 priority
+  sed -i'' -e 's,#precedence ::ffff:0:0/96  100,precedence ::ffff:0:0/96  100,' /etc/gai.conf && \
+  # enable multiplatform feature
+  gem install --no-document --install-dir /usr/share/rubygems-integration/all bundler && \
+  rm -rf /var/lib/apt/lists/*

--- a/td-agent/apt/debian-bullseye/qemu-dummy-static
+++ b/td-agent/apt/debian-bullseye/qemu-dummy-static
@@ -1,0 +1,33 @@
+#!/bin/sh
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Do nothing. This exists only for not requiring qemu-aarch64-static copy.
+# Recent Debian (buster or later) and Ubuntu (18.10 or later) on amd64 hosts or
+# arm64 host don't require qemu-aarch64-static in Docker image. But old Debian
+# and Ubuntu hosts on amd64 require qemu-aarch64-static in Docker image.
+#
+# We use "COPY qemu* /usr/bin/" in Dockerfile. If we don't put any "qemnu*",
+# the "COPY" is failed. It means that we always require "qemu*" even if we
+# use recent Debian/Ubuntu or arm64 host. If we have this dummy "qemu*" file,
+# the "COPY" isn't failed. It means that we can copy "qemu*" only when we
+# need.
+#
+# See also "script" in dev/tasks/linux-packages/azure.linux.arm64.yml.
+# Azure Pipelines uses old Ubuntu (18.04).
+# So we need to put "qemu-aarch64-static" into this directory.


### PR DESCRIPTION
Debian 11 "bullseye" released

https://www.debian.org/News/2021/20210814
