### PR TITLE
MSI: Get fluentd version correctly

### DIFF
--- a/td-agent/msi/assets/td-agent-version.rb
+++ b/td-agent/msi/assets/td-agent-version.rb
@@ -1,6 +1,7 @@
+require 'rubygems'
+require 'fluent/version'
+
 td_agent_config = File.expand_path(File.join(File.dirname(__FILE__), "../share/config"))
 require td_agent_config
-Dir.glob("#{ENV['TD_AGENT_TOPDIR'].gsub(/\\/, '/')}/lib/ruby/**/bundler/**/fluent/version.rb").each do |v|
-  require v.delete_suffix(".rb")
-end
+
 puts "td-agent #{PACKAGE_VERSION} fluentd #{Fluent::VERSION} (#{FLUENTD_REVISION})"


### PR DESCRIPTION
Require rubygems to find correct fluent/version.rb
Otherwise `td-agent --version` causes following error because `bundler`
directory doesn't exist anymore:

      C:/opt/td-agent/bin//../bin/td-agent-version.rb:6:in `<main>': uninitialized constant Fluent (NameError)
