### PR TITLE
MSI: Fix log file name in install-test

### DIFF
--- a/td-agent/msi/install-test.ps1
+++ b/td-agent/msi/install-test.ps1
@@ -27,10 +27,10 @@ if ($conf -ne "td-agent\etc\td-agent\td-agent.conf") {
 }
 Write-Host "Succeeded to find td-agent.conf"
 
-# td-agent.log should not be removed
-$conf = (Get-ChildItem -Path "c:\\opt" -Filter "td-agent.log" -Recurse -Name)
-if ($conf -ne "td-agent\td-agent.log") {
-  Write-Host "Failed to find td-agent.log: <${conf}>"
+# td-agent-0.log should not be removed
+$conf = (Get-ChildItem -Path "c:\\opt" -Filter "td-agent-0.log" -Recurse -Name)
+if ($conf -ne "td-agent\td-agent-0.log") {
+  Write-Host "Failed to find td-agent-0.log: <${conf}>"
   [Environment]::Exit(1)
 }
-Write-Host "Succeeded to find td-agent.log"
+Write-Host "Succeeded to find td-agent-0.log"


### PR DESCRIPTION
Since log rotation is introduced at #343, a number suffix is added to
log file name.

td-agent.log ->
td-agent-0.log

Signed-off-by: Takuro Ashie <ashie@clear-code.com>